### PR TITLE
Add newly hosted ML course

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Many instructors have admirably [advocated against taking their own DataCamp cou
 
 [Structural Equation Modeling with lavaan in R](http://statstools.com/learn/structural-equation-modeling/)
 
+[Supervised Machine Learning: Case Studies in R](https://supervised-ml-course.netlify.com/)
+
 [Introduction to Machine Learning](https://lagunita.stanford.edu/courses/HumanitiesSciences/StatLearning/Winter2016/course/)
 
 [Unsupervised Learning in R](https://lagunita.stanford.edu/courses/HumanitiesSciences/StatLearning/Winter2016/course/)


### PR DESCRIPTION
As referenced in [this blog post](https://juliasilge.com/blog/supervised-ml-course/), Julia Silge now has a new place to host a revamped version of her supervised ML course. 

Tried to put in a sensible location in the list - though obviously move it if there is an order I don't know!